### PR TITLE
Prevent easy addition of spaces and other characters to re-use commands.

### DIFF
--- a/twitch_master.js
+++ b/twitch_master.js
@@ -304,8 +304,6 @@ function main()
 	});
 
 	twitch_chat.addListener('message#' + config['nick'], function(from, msg) {
-		msg = msg.trim();
-  
 		if (exports.map[msg] != null) {
 			console.log(from + ': ' + msg + ' -> ' + exports.map[msg]);
 			pub.send(['client-console', '> ' + from + ': ' + msg]);


### PR DESCRIPTION
Twitch's built-in 30s timer of chat comments is a good rate-limiter, however it is being abused by simply adding spaces to the beginning or end of a message. This easily allows a single party to control the chain of commands, and frustrates many users alike.

![command spamming](https://i.imgur.com/i3Mbcnh.jpg)

Removing trim() will cause only commands without extra fluff to be accepted. On the other hand, this solution could backfire as users who would successfully be able to run system_reset twice in a row, would go unopposed as those who voted 'nop' would not be able to do so for another 30s.
