### PR TITLE
Enabled the use of kvm. *MUST* ensure kvm and kvm-intel or kvm-amd are

### DIFF
--- a/lib/launch.sh
+++ b/lib/launch.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-qemu-system-x86_64 -cdrom ~/archlinux-2015.10.01-dual.iso -hda ~/Arch.img -net nic -net user -m 1G -vnc localhost:0 -monitor stdio -localtime -qmp tcp:localhost:4444,server,nowait -no-shutdown
+qemu-system-x86_64 -enable-kvm -cdrom ~/archlinux-2015.10.01-dual.iso -hda ~/Arch.img -net nic -net user -m 1G -vnc localhost:0 -monitor stdio -localtime -qmp tcp:localhost:4444,server,nowait -no-shutdown


### PR DESCRIPTION
loaded. lsmod | grep kvm. This requires the host to have virtualization
support.
